### PR TITLE
CI/CD: ensure Gradle deps are available to dependabot

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -94,6 +94,8 @@ jobs:
 
     dependency-submission:
       runs-on: ubuntu-latest
+      permissions:
+        contents: write
       steps:
        - name: Checkout sources
          uses: actions/checkout@v4

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -19,9 +19,9 @@ jobs:
           lang: [ en, nl ]
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
-        - uses: actions/setup-node@v3
+        - uses: actions/setup-node@v4
           with:
             node-version: '18'
             cache: yarn
@@ -43,7 +43,7 @@ jobs:
     build-war:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - uses: actions/setup-java@v2
           with:
@@ -57,7 +57,7 @@ jobs:
         - name: Build
           run: ./gradlew build
 
-        - uses: actions/upload-artifact@v3
+        - uses: actions/upload-artifact@v4
           with:
             name: war
             path: build/libs/irma_email_issuer.war
@@ -70,7 +70,7 @@ jobs:
         contents: read
         security-events: write
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - uses: actions/setup-java@v2
           with:
@@ -79,15 +79,24 @@ jobs:
             cache: gradle
 
         - name: Initialize CodeQL
-          uses: github/codeql-action/init@v2
+          uses: github/codeql-action/init@v3
           with:
             languages: java
             queries: security-and-quality
 
         - name: Autobuild
-          uses: github/codeql-action/autobuild@v2
+          uses: github/codeql-action/autobuild@v3
 
         - name: Perform CodeQL Analysis
-          uses: github/codeql-action/analyze@v2
+          uses: github/codeql-action/analyze@v3
           with:
             category: "/language:java"
+
+    dependency-submission:
+      runs-on: ubuntu-latest
+      steps:
+       - name: Checkout sources
+         uses: actions/checkout@v4
+       - name: Generate and submit dependency graph
+         uses: gradle/actions/dependency-submission@v3
+      


### PR DESCRIPTION
I have my doubts whether the `build.gradle` is scanned by Dependabot at the moment. I found this that might improve things.
https://github.com/marketplace/actions/build-with-gradle#the-dependency-submission-action