### PR TITLE
Fixing template issues

### DIFF
--- a/src/main/resources/email-en.html
+++ b/src/main/resources/email-en.html
@@ -64,7 +64,7 @@
             
             <!-- Alternate Link -->
             <tr>
-              <td style="padding: 16px 24px; font-size: 18px; color: #a3244a; text-align: left;">
+              <td style="padding: 16px 24px; font-size: 18px; color: #a3244a !important; text-align: left;">
                 If the button doesn&#39;t work, you can also verify your email by using the link below:<br />
                 <a href="%1$s" style="color:blue underline;">%1$s</a>
               </td>

--- a/src/main/resources/email-nl.html
+++ b/src/main/resources/email-nl.html
@@ -38,7 +38,7 @@
                 <p>Beste Yivi-gebruiker,</p>
                 <p>
                 Bedankt voor het gebruiken van Yivi, jouw privacyvriendelijke identity wallet!<br />
-                Klik op de knop hieronder om je e-mailadres te verifiëren en toe te voegen aan jouw Yivi-app.
+                Klik op de knop hieronder om je e-mailadres te verifi&euml;ren en toe te voegen aan jouw Yivi-app.
                 </p>
               </td>
             </tr>
@@ -64,8 +64,8 @@
             
             <!-- Alternate Link -->
             <tr>
-              <td style="padding: 16px 24px; font-size: 18px; color: #a3244a; text-align: left;">
-                Werkt deze knop niet? Gebruik dan de onderstaande link om je e-mailadres te verifiëren:<br />
+              <td style="padding: 16px 24px; font-size: 18px; color: #a3244a !important; text-align: left;">
+                Werkt deze knop niet? Gebruik dan de onderstaande link om je e-mailadres te verifi&euml;ren:<br />
                 <a href="%1$s" style="color:blue underline;">%1$s</a>
               </td>
             </tr>

--- a/src/main/resources/email-nl.html
+++ b/src/main/resources/email-nl.html
@@ -34,7 +34,7 @@
             </tr>
             <!-- Body Text -->
             <tr>
-              <td style="padding: 16px 24px; font-size: 18px; color: #a3244a; text-align: left;">
+              <td style="padding: 16px 24px; font-size: 18px; color: #a3244a !important; text-align: left;">
                 <p>Beste Yivi-gebruiker,</p>
                 <p>
                 Bedankt voor het gebruiken van Yivi, jouw privacyvriendelijke identity wallet!<br />


### PR DESCRIPTION
Things modified:

email-nl.html: changing the Diacritic e with &euml; equivalant, since gmail seems to ignore meta header enforcing UTF-8, therefore the [issue 60](https://github.com/privacybydesign/irma_email_issuer/issues/60)  happens.

both email-nl and email-en: add !important to force the color, since some email engines override [issue 58](https://github.com/privacybydesign/irma_email_issuer/issues/58). 

Note: These issues only can be checked to be resolved by checking the image and actually sending the email, since locally the templates appear normal.
