### PR TITLE
Revert "chore: Upgrade vulnerable dependencies"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,19 +29,19 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.glassfish.jersey.core:jersey-server:3.1.10'
-    implementation 'org.glassfish.jersey.containers:jersey-container-servlet:3.1.10'
-    implementation 'org.glassfish.jersey.inject:jersey-hk2:3.1.10'
-    implementation 'ch.qos.logback:logback-classic:1.5.17'
+    implementation 'org.glassfish.jersey.core:jersey-server:3.0.12'
+    implementation 'org.glassfish.jersey.containers:jersey-container-servlet:3.0.12'
+    implementation 'org.glassfish.jersey.inject:jersey-hk2:3.0.12'
+    implementation 'ch.qos.logback:logback-classic:1.5.3'
     implementation 'com.sun.mail:jakarta.mail:2.0.1'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
-
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    
+    implementation 'io.jsonwebtoken:jjwt:0.12.5'
     implementation 'redis.clients:jedis:5.1.5'
-    implementation 'com.google.code.gson:gson:2.12.1'
-    implementation 'org.apache.commons:commons-lang3:3.17.0'
-    implementation 'org.bouncycastle:bcpkix-jdk18on:1.80'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
+    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'org.apache.commons:commons-lang3:3.14.0'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.77'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
 
     // Source dependencies. Check settings.gradle for the source repositories.


### PR DESCRIPTION
Revert the dependency update for a little while so we can first deploy a stable versioned release.